### PR TITLE
Update Remove-AppxApps.ps1

### DIFF
--- a/src/Remove-AppxApps.ps1
+++ b/src/Remove-AppxApps.ps1
@@ -114,7 +114,6 @@ param (
         # "Microsoft.WindowsSoundRecorder_8wekyb3d8bbwe",
         # "Microsoft.WindowsTerminal_8wekyb3d8bbwe",
         "Microsoft.XboxApp_8wekyb3d8bbwe",
-        "Microsoft.XboxGameCallableUI_cw5n1h2txyewy",
         "Microsoft.XboxGameOverlay_8wekyb3d8bbwe",
         "Microsoft.XboxGamingOverlay_8wekyb3d8bbwe",
         "Microsoft.YourPhone_8wekyb3d8bbwe",

--- a/src/Remove-AppxApps.ps1
+++ b/src/Remove-AppxApps.ps1
@@ -42,7 +42,7 @@
 
         .NOTES
  	        NAME: Remove-AppxApps.ps1
-	        VERSION: 3.0
+	        VERSION: 3.5
 	        AUTHOR: Aaron Parker
 	        TWITTER: @stealthpuppy
 
@@ -240,15 +240,15 @@ process {
             #Write-Verbose -Message "Get user package: [$Name]."
             $Value = "Removed"; $Status = 0; $Msg = "None"
             if ($PSCmdlet.ShouldProcess($Name, "Remove User app")) {
-                Get-AppxPackage -Name $Name | Remove-AppxPackage -ErrorAction "SilentlyContinue"
+                Get-AppxPackage -Name $Name | Remove-AppxPackage -ErrorAction "SilentlyContinue" | Out-Null
             }
         }
         catch [System.Exception] {
             $Value = "Failed"; $Status = 1; $Msg = $_.Exception.Message
         }
         $Output = [PSCustomObject]@{
-            Type   = "UserPackage"
             Name   = $Name
+            Type   = "UserPackage"
             State  = $Value
             Status = $Status
             Error  = $Msg
@@ -262,15 +262,15 @@ process {
                 $Value = "Removed"; $Status = 0; $Msg = "None"
                 if ($PSCmdlet.ShouldProcess($Name, "Remove Provisioned app")) {
                     Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $Name } | `
-                        Remove-AppxProvisionedPackage -Online -AllUsers -ErrorAction "SilentlyContinue"
+                        Remove-AppxProvisionedPackage -Online -AllUsers -ErrorAction "SilentlyContinue" | Out-Null
                 }
             }
             catch [System.Exception] {
                 $Value = "Failed"; $Status = 1; $Msg = $_.Exception.Message
             }
             $Output = [PSCustomObject]@{
-                Type   = "ProvisionedPackage"
                 Name   = $Name
+                Type   = "ProvisionedPackage"
                 State  = $Value
                 Status = $Status
                 Error  = $Msg


### PR DESCRIPTION
* Renames parameters from `BlockList` and `AllowList` to `PackageFamilyNameBlockList` and `PackageFamilyNameAllowList` to make it easier to know what data these parameters expect
* Adds `Microsoft.XboxGameCallableUI*` to the list of protected AppX packages
* Fixes an issue in which only the last package was being removed from the list of provisioned system packages
* Removes `Remove-AppxPackage -AllUsers` which was not completing successfully - packages from the System account will not be removed
* Updates the output to include Package name, uninstall type (user or provisioned package), Removed success/fail state, and error message (if an error was encountered)